### PR TITLE
fiddley: Make sure to free Fiddle::Pointer

### DIFF
--- a/lib/gr_commons/fiddley.rb
+++ b/lib/gr_commons/fiddley.rb
@@ -188,7 +188,7 @@ module GRCommons
           @size = @ptr.size
         else
           @size = type2size(type) * num
-          @ptr = Fiddle::Pointer.malloc(@size)
+          @ptr = Fiddle::Pointer.malloc(@size, Fiddle::RUBY_FREE)
         end
       end
 


### PR DESCRIPTION
@kou
I think `RUBY_FREE` should be used in most cases when using `Fiddle::Pointer`. In the original Fiddley, [`RUBY_FREE` is not set](https://github.com/unak/fiddley/blob/6f5daf5451d00d7b9cafa4d9c09fedb68088dd10/lib/fiddley/memory_pointer.rb#L18). Should I change it this way?