### PR TITLE
debug RuntimeError when requiring 'gr/plot'.

### DIFF
--- a/lib/gr.rb
+++ b/lib/gr.rb
@@ -274,6 +274,32 @@ module GR
       end
     end
 
+    # Draw a text at position `x`, `y` using the given options and current text
+    # attributes.
+    #
+    # @param x      [Numeric] The X coordinate of the starting position of the text string
+    # @param y      [Numeric] The Y coordinate of the starting position of the text string
+    # @param string [String]  The text to be drawn
+    # @param opts   [Integer] Bit mask including text options (GR_TEXT_USE_WC,
+    # GR_TEXT_ENABLE_INLINE_MATH)
+    #
+    # The values for `x` and `y` specify the text position. If the GR_TEXT_USE_WC
+    # option is set, they are interpreted as world cordinates, otherwise as
+    # normalized device coordinates. The string may contain new line characters
+    # and inline math expressions ($...$). The latter are only taken into account,
+    # if the GR_TEXT_ENABLE_INLINE_MATH option is set.
+    # The attributes that control the appearance of text are text font and
+    # precision, character expansion factor, character spacing, text color index,
+    # character height, character up vector, text path and text alignment.
+    #
+    # @!method text
+
+    def inqtextx(x, y, string, opts)
+      inquiry [{ double: 4 }, { double: 4 }] do |tbx, tby|
+        super(x, y, string, opts, tbx, tby)
+      end
+    end
+
     # Allows you to specify a polygonal shape of an area to be filled.
     #
     # @param x [Array, NArray] A list containing the X coordinates

--- a/lib/gr/ffi.rb
+++ b/lib/gr/ffi.rb
@@ -35,7 +35,7 @@ module GR
     try_extern 'void gr_text(double, double, char *)'
     try_extern 'void gr_textx(double, double, char *, int)'
     try_extern 'void gr_inqtext(double, double, char *, double *, double *)'
-    try_extern 'gr_inqtextx(double, double, char *, int, double *, double *)'
+    try_extern 'void gr_inqtextx(double, double, char *, int, double *, double *)'
     try_extern 'void gr_fillarea(int, double *, double *)'
     try_extern 'void gr_cellarray(double, double, double, double, ' \
                'int, int, int, int, int, int, int *)'

--- a/test/gr_test.rb
+++ b/test/gr_test.rb
@@ -35,6 +35,12 @@ class GRTest < Test::Unit::TestCase
       assert_kind_of Array, GR.inqtext(0, 0, 'Ruby')
     end
 
+    def test_inqtextx
+      assert_kind_of Array, GR.inqtextx(0, 0, 'Ruby',
+                                        GR::TEXT_ENABLE_INLINE_MATH | \
+                                        GR::TEXT_USE_WC)
+    end
+
     def test_linetype
       assert_nil GR.setlinetype(3)
       assert_equal 3, GR.inqlinetype


### PR DESCRIPTION
I encountered the following RuntimeError. So I correct the try_extern signature, add definition, and a test for it.

```
>> require 'gr/plot'
RuntimeError: can't parse the function prototype: gr_inqtextx(double, double, char *, int, double *, double *)
```